### PR TITLE
update github-action versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,10 +10,10 @@ jobs:
     environment: Staging
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -46,10 +46,10 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/dev.actions.yml
+++ b/.github/workflows/dev.actions.yml
@@ -26,10 +26,10 @@ jobs:
       URL_UT: ${{ secrets.URL_UT }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/liquidate.yml
+++ b/.github/workflows/liquidate.yml
@@ -10,10 +10,10 @@ jobs:
     environment: Staging
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -35,10 +35,10 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/qat.actions.yml
+++ b/.github/workflows/qat.actions.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/rebalance.yml
+++ b/.github/workflows/rebalance.yml
@@ -8,10 +8,10 @@ jobs:
     environment: Staging
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -34,10 +34,10 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/trigger-trade.yml
+++ b/.github/workflows/trigger-trade.yml
@@ -8,10 +8,10 @@ jobs:
     environment: Staging
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -44,10 +44,10 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
Update the following actions to use Node.js 20: 
- [x] actions/checkout@v3 -> v4.1.1
- [x] actions/setup-python@v4.3.0 -> v5.0.0