### PR TITLE
limit notional value

### DIFF
--- a/modules/accumulate.py
+++ b/modules/accumulate.py
@@ -24,6 +24,7 @@ if 'paper' in BASE_URL:
     cost_basis = 100 / float(len(tickers))
 else:
     cost_basis = cash_in_account / (TRADING_DAYS * float(len(tickers)))
+    cost_basis = round(cost_basis, 2)
 
 if cash_in_account < 10.0:
     print('Insufficient funds.')


### PR DESCRIPTION
- alpaca.common.exceptions.APIError: {"code":42210000,"message":"notional value must be limited to 2 decimal places"}